### PR TITLE
disallow use of this outside class methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,8 @@ module.exports = {
       "no-multi-assign": 0,
       "no-unused-expressions": 0,
       "no-restricted-syntax": "warn",
+      "no-invalid-this": 0,
+      "babel/no-invalid-this": 1,
       "consistent-return": "warn",
       "max-len": 0,
       "curly": "error",

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,103 @@
+{
+  "_args": [
+    [
+      {
+        "raw": "eslint-config-chefsplate",
+        "scope": null,
+        "escapedName": "eslint-config-chefsplate",
+        "name": "eslint-config-chefsplate",
+        "rawSpec": "",
+        "spec": "latest",
+        "type": "tag"
+      },
+      "/Users/shan/sandbox/eslint-chefsplate"
+    ],
+    [
+      {
+        "raw": "eslint-config-chefsplate",
+        "scope": null,
+        "escapedName": "eslint-config-chefsplate",
+        "name": "eslint-config-chefsplate",
+        "rawSpec": "",
+        "spec": "latest",
+        "type": "tag"
+      },
+      "/Users/shan/sandbox/eslint-chefsplate"
+    ],
+    [
+      {
+        "raw": "eslint-config-chefsplate@^1.0.1",
+        "scope": null,
+        "escapedName": "eslint-config-chefsplate",
+        "name": "eslint-config-chefsplate",
+        "rawSpec": "^1.0.1",
+        "spec": ">=1.0.1 <2.0.0",
+        "type": "range"
+      },
+      "/Users/james/Dev/chefs-plate/web2"
+    ]
+  ],
+  "_from": "eslint-config-chefsplate@^1.0.1",
+  "_id": "eslint-config-chefsplate@1.0.5",
+  "_inCache": true,
+  "_location": "/eslint-config-chefsplate",
+  "_nodeVersion": "7.10.1",
+  "_npmOperationalInternal": {
+    "host": "s3://npm-registry-packages",
+    "tmp": "tmp/eslint-config-chefsplate-1.0.5.tgz_1512967502961_0.7932015531696379"
+  },
+  "_npmUser": {
+    "name": "shan-du",
+    "email": "shan.du@chefsplate.com"
+  },
+  "_npmVersion": "4.2.0",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "eslint-config-chefsplate@^1.0.1",
+    "scope": null,
+    "escapedName": "eslint-config-chefsplate",
+    "name": "eslint-config-chefsplate",
+    "rawSpec": "^1.0.1",
+    "spec": ">=1.0.1 <2.0.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "#DEV:/"
+  ],
+  "_resolved": "https://registry.npmjs.org/eslint-config-chefsplate/-/eslint-config-chefsplate-1.0.5.tgz",
+  "_shasum": "45a115897b23d1573758deb9fc2d005a01761169",
+  "_shrinkwrap": null,
+  "_spec": "eslint-config-chefsplate@^1.0.1",
+  "_where": "/Users/james/Dev/chefs-plate/web2",
+  "author": "",
+  "dependencies": {},
+  "description": "ES Lint Config For Chefs Plate Apps",
+  "devDependencies": {},
+  "directories": {},
+  "dist": {
+    "shasum": "45a115897b23d1573758deb9fc2d005a01761169",
+    "tarball": "https://registry.npmjs.org/eslint-config-chefsplate/-/eslint-config-chefsplate-1.0.5.tgz"
+  },
+  "license": "ISC",
+  "main": "index.js",
+  "maintainers": [
+    {
+      "name": "shan-du",
+      "email": "shan.du@chefsplate.com"
+    },
+    {
+      "name": "h36ahmed",
+      "email": "h36ahmed@uwaterloo.ca"
+    }
+  ],
+  "name": "eslint-config-chefsplate",
+  "optionalDependencies": {},
+  "peerDependencies": {
+    "eslint": ">= 3"
+  },
+  "readme": "ERROR: No README data found!",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "version": "1.0.6"
+}


### PR DESCRIPTION
Avoid scenarios where `this` may be undefined. See https://eslint.org/docs/rules/no-invalid-this for rule details.

Use "babel/no-invalid-this" so that class property arrow functions are still allowed to use this, e.g.   

```
handleLinkPayments = () => {
    const { navigation: { navigate } } = this.props;

    navigate('Payments');
  }
```

on a Class (react component) is still valid.