### PR TITLE
disallow providing radix of 10 (is default)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ module.exports = {
       "expect": true
     },
     "rules": {
-      "radix": ["error", "always"],
+      "radix": ["error", "as-needed"],
       "react/jsx-quotes": 0,
       "react/jsx-filename-extension": 0,
       "react/no-danger": 0,


### PR DESCRIPTION
Error when passing redundant radix value of 10 to parsInt()